### PR TITLE
Informacje od tłumaczy

### DIFF
--- a/src/ch00-00-introduction.md
+++ b/src/ch00-00-introduction.md
@@ -204,3 +204,13 @@ Pliki źródłowe, z których wygenerowana została niniejsza książka, można 
 na [GitHubie][book].
 
 [book]: https://github.com/paytchoo/book-pl/tree/master/src
+
+## Informacje od tłumaczy
+
+W niniejszej książce znajdziesz wiele przykładów programów oraz wycinki kodu,
+w których: łańcuchy znaków w makrach `println!`, komentarze, a czasem nawet
+nazwy projektów Cargo; zostały przetłumaczone. Jest to zabieg tłumaczy mający
+na celu jak największe usunięcie przeszkody języka angielskiego w zrozumieniu
+pojęć zawartych w tej książce. Prosimy, abyś rozważył(a) użycie języka angielskiego, kiedy
+zdecydujesz się na udostępnienie swojego kodu, zarówno w przypadku Rusta przy udostępnianiu własnych skrzyń,
+ale także w przypadku wszelkich innych języków programowania.


### PR DESCRIPTION
Na pierwszej stronie, w `ch00-00-introduction` dodałem małą notatkę o wykorzystaniu języka polskiego w kodzie. Cel jest taki, aby zachęcić czytających do korzystania z języka angielskiego.

Tym PRem bardziej chciałem zachęcić do dyskusji niż narzucić słownictwo, jakby ktoś był w stanie lepiej to ująć, to myślę że byłoby to bardzo korzystne dla ekosystemu Rusta i przyszłych polskich Rustafarianów.